### PR TITLE
Fix version select having no background

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -105,6 +105,7 @@ footer.site-footer {
     position: -webkit-sticky;
     position: sticky;
     bottom: 0;
+    background-color: $background-color;
   }
 
   > ul {
@@ -185,6 +186,7 @@ footer.site-footer {
         position: sticky;
         top: 0;
         padding-top: 24px;
+        margin-bottom: 80px;
       }
     }
 


### PR DESCRIPTION
Set a background for the version select div so it doesn't look like this ("clipping" into the other text) anymore:
![2018-07-05-182040_847x1052_scrot](https://user-images.githubusercontent.com/3718398/42335310-3d6a764c-8080-11e8-9a80-978e7d10a760.png)

With this PR it looks like this:
![2018-07-05-182044_847x1052_scrot](https://user-images.githubusercontent.com/3718398/42335317-458ca818-8080-11e8-8faf-0e0a69ca1f34.png)

/cc @travisn Here you go :slightly_smiling_face: 