### PR TITLE
Should be using `npm ci`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ _data/projects.json: node_modules docs $(wildcard docs/*)
 
 # Install node_modules
 node_modules: package.json package-lock.json
-	npm install
+	npm ci
 	@touch node_modules


### PR DESCRIPTION
We should be using [npm ci](https://docs.npmjs.com/cli/ci.html) during CI builds.
I caught this system updating the lock file during a CI build here:
https://github.com/rook/rook.github.io/commit/6857cde3e1ae0d364e7e707530cc27852185f534#diff-32607347f8126e6534ebc7ebaec4853d