### PR TITLE
Make base URL HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: rook.io
-url: "http://rook.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://rook.io" # the base hostname & protocol for your site, e.g. http://example.com
 google_analytics: UA-93639004-1
 
 # Build settings


### PR DESCRIPTION
In pursuance of resolving #60, this PR updates the base URL for the site to an HTTPS address to avoid mixed content issues.