### PR TITLE
index.html: update note fo contributors/downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ stylesheet: index
         </div>
     </section>
     <h1 class="text-center">Who loves Rook?</h1>
-    <p class="text-center">With hundreds of contributors and millions of downloads of the Rook software, this true community-driven effort is putting dynamic orchestration, high performance, and solid reliability in the hands of a global user base.<br /><br />Rook is deployed in production across multiple industries, enabling them to store, deliver & protect the data that powers their businesses.</p>
+    <p class="text-center">With a hundred contributors and tens of millions of downloads of the Rook software, this true community-driven effort is putting dynamic orchestration, high performance, and solid reliability in the hands of a global user base.<br /><br />Rook is deployed in production across multiple industries, enabling them to store, deliver & protect the data that powers their businesses.</p>
     <section class="grid-middle affiliates">
         <div class="col-2_xs-4">
             <a href="//pacificresearchplatform.org/">


### PR DESCRIPTION
Rook has precisely one hundred contributors, which does not count as
"hundreds". Rook must reach 200+ contributors for the "hundreds" wording
to have been accurate. This was changed to "a hundred".

There are a recorded 21 million Docker pulls currently, and that now
counts as "tens of millions", up from the previous "millions".

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>