### PR TITLE
allow setting custom release by index from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,5 @@ defaults:
 
 sass:
   sass_dir: ./_scss
+
+current_release_index: 1

--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -6,9 +6,9 @@
 {% assign emailLink = 'mailto:info@rook.io' %}
 {% assign featureRequestLink = '//github.com/rook/rook/issues' %}
 {% assign forumLink = '//groups.google.com/forum/#!forum/rook-dev' %}
-{% assign gettingStartedLink = '/docs/rook/' | append: site.data.projects[0].versions[0].version | append: '/quickstart-toc.html' | relative_url %}
+{% assign gettingStartedLink = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/quickstart-toc.html' | relative_url %}
 {% assign githubLink = '//github.com/rook/rook' %}
-{% assign latestDocs = '/docs/rook/' | append: site.data.projects[0].versions[0].version | append: '/' | relative_url %}
+{% assign latestDocs = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/' | relative_url %}
 {% assign nexentaLink = '//nexenta.com' %}
 {% assign redHatLink = '//www.redhat.com' %}
 {% assign slackLink = '//slack.rook.io/' %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -5,7 +5,7 @@ layout: default
 {% assign url = page.url | split: '/' %}
 {% assign currentProject = url[2] %}
 {% assign currentVersion = url[3] %}
-{% assign latestVersion = site.data.projects[0].versions[0].version %}
+{% assign latestVersion = site.data.projects[0].versions[site.current_release_index].version %}
 {% assign currentProjectPath = '/docs/' | append: currentProject | append: '/' %}
 {% assign currentProjectVersionPath = currentProjectPath | append: currentVersion | append: '/' %}
 {% assign project = site.data.projects | where_exp: 'item', 'item.project == currentProject' | first %}
@@ -41,7 +41,7 @@ layout: default
       </div>
     {% elsif currentVersion != latestVersion %}
       <div class="alert old">
-        <p><b>PLEASE NOTE</b>: This document applies to {{ currentVersion }} version and not to the latest release {{ latestVersion }}</p>
+        <p><b>PLEASE NOTE</b>: This document applies to {{ currentVersion }} version and not to the latest <strong>stable</strong> release {{ latestVersion }}</p>
         <strong>Documentation for other releases can be found by using the version selector in the left bottom of any doc page.</strong>
       </div>
     {% endif %}
@@ -117,7 +117,7 @@ layout: default
             itemDom.style.height = fullHeight;
             flushCss(itemDom);
             itemDom.style.transition = '';
-          } 
+          }
           itemDom.style.height = MAIN_ITEM_HEIGHT + 'px';
         }
 
@@ -133,7 +133,7 @@ layout: default
       itemDom.style.height = MAIN_ITEM_HEIGHT + 'px';
     }
   }
-  
+
   var menuDom = document.getElementById('docs-ul');
   for (var i = 0; i < menu.length; i++) {
     var item = menu[i];
@@ -142,7 +142,7 @@ layout: default
     if (item.childCurrent) {
       itemDom.classList.add('childCurrent');
     }
-    
+
     if (item.children) {
       addArrow(itemDom);
       itemDom.classList.add('children');


### PR DESCRIPTION
The new variable in _config.yaml introduced is named:
```
current_release_index
```
Example: v1.1, v1.0 and v0.9 is out, when setting the index to 1 this
would cause the latest docs links to point to v1.0 instead of v1.1

Signed-off-by: Alexander Trost <galexrt@googlemail.com>