### PR TITLE
Change release index to 0 for v1.1 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 1
+current_release_index: 0


### PR DESCRIPTION
v1.1 is out of beta and in release, so change the release index back to
0.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>