### PR TITLE
style: use red background for master branch warning

### DIFF
--- a/css/docs.scss
+++ b/css/docs.scss
@@ -417,7 +417,11 @@
 
     &.master {
       border-color: #f44336;
-      color: #f44336;
+      background-color: #f44336;
+      color: #ffffff;
+      p {
+        color: #ffffff;
+      }
     }
 
     &.old {


### PR DESCRIPTION
This changes the background of the "you are on master" branch docs box
to be red instead of transparent and the text being red.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

![image](https://user-images.githubusercontent.com/3718398/65433166-d2e22f80-de1c-11e9-96af-71f9cf6cb5ee.png)

This hopefully makes the warning more visible to users.