### PR TITLE
Add OpenGraph Protocol headers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,11 @@
 # Site settings
-title: rook.io
+title: Rook
 url: "https://rook.io" # the base hostname & protocol for your site, e.g. http://example.com
 google_analytics: UA-93639004-1
+twitter_username: rook_io
+github_username:  rook
+type: website
+image: /images/favicon_192x192.png
 
 # Build settings
 markdown: kramdown

--- a/_includes/metas-ogp.html
+++ b/_includes/metas-ogp.html
@@ -1,0 +1,18 @@
+
+    <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <!-- # Opengraph protocol properties: https://ogp.me/ -->
+    <meta name="author" content="{% if page.author %}{{ page.author | join: ', ' }}{% else %}The {{ site.title }} website team, {{ autharray | uniq | join: ", " }}{% endif %}" >
+    {% if page.author %}<meta property="og:type" content="article" >{% endif %}
+    <meta name="twitter:card" content="summary">
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="keywords" content="{% if page.categories %}{{ page.categories | join: ', ' }}{% else %}{% for category in site.categories %}{{ category | first | slugify }}, {% endfor %}{% endif %}" >
+    <meta property="og:title" content="{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}">
+    <meta property="og:type" content="{% if page.type %}{{ page.type }} | {{ site.type }}{% else %}{{ site.type }}{% endif %}">
+    <meta property="og:url" content="{{site.url}}{{ page.url }}" >
+    <meta property="og:image" content="{% if page.image %}{{site.url}}{{ page.image }} | {{site.url}}{{ site.image }}{% else %}{{site.url}}{{ site.image }}{% endif %}">
+    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" >
+    <meta property="og:site_name" content="{{ site.title }}" >
+    <meta property="og:article:author" content="{% if page.author %}{{ page.author | join: ', ' }}{% else %}The {{ site.title }} website team{% endif %}" >
+    <meta property="og:article:published_time" content="{% if page.date %}{{ page.date }}{% else %}{{ site.time }}{% endif %}" >
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}">
+    <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-    <title>{{ page.doctitle | default: "Rook" | escape }}</title>
-
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+
+    {% include metas-ogp.html %}
 
     {% include favicon.html %}
 


### PR DESCRIPTION
OpenGraph protocol add headers to webpages so that they provide additional information so that crawlers, etc can locate the website and extract information out of it