### PR TITLE
Point release docs to v1.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 0
+current_release_index: 1


### PR DESCRIPTION
The release documentation should still point to v1.1 until v1.2 is
officially released. v1.2 is still in beta.
