### PR TITLE
fix "Try it out" link to quickstart doc page

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -6,7 +6,7 @@
 {% assign emailLink = 'mailto:info@rook.io' %}
 {% assign featureRequestLink = '//github.com/rook/rook/issues' %}
 {% assign forumLink = '//groups.google.com/forum/#!forum/rook-dev' %}
-{% assign gettingStartedLink = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/quickstart-toc.html' | relative_url %}
+{% assign gettingStartedLink = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/quickstart.html' | relative_url %}
 {% assign githubLink = '//github.com/rook/rook' %}
 {% assign latestDocs = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/' | relative_url %}
 {% assign nexentaLink = '//nexenta.com' %}


### PR DESCRIPTION
This fixes the "Try it out" link to point to the renamed quickstart
guide list.

This resolves https://github.com/rook/rook/issues/4595.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>