### PR TITLE
Clarify on http://rook.io that rook automates management, but is not the data plane

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ stylesheet: index
     <section class="grid-middle hero">
         <div class="col-5_md-12">
             <h1>Open-Source,<br />Cloud-Native Storage for Kubernetes</h1>
-            <p>Production ready File, Block and Object Storage</p>
+            <p>Production ready management for File, Block and Object Storage</p>
             <a class="button" href="{{ gettingStartedLink }}">Try it out now</a>
         </div>
         <div class="col-7_md-12_md-first">
@@ -21,8 +21,8 @@ stylesheet: index
             <img src="{{ "/images/index-what-is-rook.svg" | relative_url }}" />
         </div>
         <div class="col-6_md-12">
-            <h2>A Storage Orchestrator for Kubernetes</h2>
-            <p>Rook turns distributed storage systems into self-managing, self-scaling, self-healing storage services. It automates the tasks of a storage administrator: deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management.<br /><br />Rook uses the power of the Kubernetes platform to deliver its services: cloud-native container management, scheduling, and orchestration.</p>
+            <h2>Storage Operators for Kubernetes</h2>
+            <p>Rook turns distributed storage systems into self-managing, self-scaling, self-healing storage services. It automates the tasks of a storage administrator: deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management.<br /><br />Rook uses the power of the Kubernetes platform to deliver its services via a Kubernetes Operator for each storage provider.</p>
             <div class="github-pills">
                 <div id="watch-pill" class="pill">
                     <a href="https://github.com/rook/rook/subscription">Watch</a>
@@ -42,7 +42,7 @@ stylesheet: index
     <section class="grid-middle storage">
         <div class="col-6_md-12">
             <h2>Multiple Storage Providers</h2>
-            <p>Rook orchestrates multiple storage solutions, providing a common framework across all of them. Choose the best storage provider for your scenarios, and Rook ensures that they all run well on Kubernetes with the same, consistent experience.</p>
+            <p>Rook orchestrates multiple storage solutions, each with a specialized Kubernetes Operator to automate management. Choose the best storage provider for your scenarios, and Rook ensures that they all run well on Kubernetes with the same, consistent experience.</p>
             <div class="grid providers">
                 <div class="col-4_xs-6"><span>Ceph</span></div>
                 <div class="col-4_xs-6"><span>EdgeFS</span></div>
@@ -74,7 +74,7 @@ stylesheet: index
         </div>
     </section>
     <h1 class="text-center">Who loves Rook?</h1>
-    <p class="text-center">With hundreds of contributors and millions of downloads of the Rook software, this true community-driven effort is putting dynamic orchestration, high performance, and solid reliability in the hands of a global user base.<br /><br />Rook is deployed in production across multiple industries, enabling them to store, deliver & protect the data that powers their businesses.</p>
+    <p class="text-center">With hundreds of contributors and millions of downloads of the Rook software, this true community-driven effort is putting dynamic orchestration, high performance, and solid reliability in the hands of a global user base.<br /><br />Rook operators are deployed in production across multiple industries, enabling them to store, deliver & protect the data that powers their businesses.</p>
     <section class="grid-middle affiliates">
         <div class="col-2_xs-4">
             <a href="//pacificresearchplatform.org/">


### PR DESCRIPTION
Per discussion with CNCF today, Rook is clearly the management plane for Kubernetes, but the storage providers are the data plane. We need to be clear in messaging that Rook is not the data plane.
