### PR TITLE
Point release docs to v1.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 0
+current_release_index: 1


### PR DESCRIPTION
The release documentation should still point to v1.2 until v1.3 is officially released. v1.3 is still in beta.
