### PR TITLE
Point release docs to v1.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 1
+current_release_index: 0


### PR DESCRIPTION
With the v1.3 release officially out the door we now point to those docs by default.
