### PR TITLE
docs: update rook mailing lists to new lists.cncf.io addresses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ publish: _data/projects.json
 		echo "no changes detected";\
 	else \
 		echo "committing changes...";\
-		git -C "$(ROOT_DIR)" -c user.email="info@rook.io" -c user.name="Rook" commit --message="docs snapshot for rook version \`$(DOCS_VERSION)\`"; \
+		git -C "$(ROOT_DIR)" -c user.email="cncf-rook-info@lists.cncf.io" -c user.name="Rook" commit --message="docs snapshot for rook version \`$(DOCS_VERSION)\`"; \
 		echo "pushing changes..."; \
 		git -C "$(ROOT_DIR)" push; \
 		echo "rook.github.io changes published"; \

--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -3,7 +3,7 @@
 {% assign cncfLink = '//www.cncf.io' %}
 {% assign communityMeetingLink = '//github.com/rook/rook#community-meeting' %}
 {% assign contributeLink = '//github.com/rook/rook/blob/master/CONTRIBUTING.md#how-to-contribute' %}
-{% assign emailLink = 'mailto:info@rook.io' %}
+{% assign emailLink = 'mailto:cncf-rook-info@lists.cncf.io' %}
 {% assign featureRequestLink = '//github.com/rook/rook/issues' %}
 {% assign forumLink = '//groups.google.com/forum/#!forum/rook-dev' %}
 {% assign gettingStartedLink = '/docs/rook/' | append: site.data.projects[0].versions[site.current_release_index].version | append: '/quickstart.html' | relative_url %}


### PR DESCRIPTION
This PR updates the readme and docs with the new Rook mailing lists hosted by the CNCF:

  - cncf-rook-info@lists.cncf.io