### PR TITLE
Add LF copyright text

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
         <a href="{{ featureRequestLink }}">Feature request</a>
       </div>
       <div class="col_sm-12">
-        <span>Top Contributers</span>
+        <span>Top Contributors</span>
         <a href="{{ cloudicalLink }}">Cloudical</a>
         <a href="{{ nexentaLink }}">Nexenta</a>
         <a href="{{ redHatLink }}">Red Hat</a>
@@ -39,8 +39,19 @@
     </div>
   </div>
   <div class="bottom">
-    <a class="logo" href="{{ "/" | relative_url }}"><img src="{{ "/images/rook-logo-small.svg" | relative_url }}" alt="rook.io" /></a>
-    <span>&#169; {{ site.time | date: '%Y' }} Rook Authors. All rights reserved.</span>
+    <div class="grid-center">
+      <div class="col-6">
+        <a class="logo" href="{{ "/" | relative_url }}"><img src="{{ "/images/rook-logo-small.svg" | relative_url }}" alt="rook.io" /></a>
+
+        <br />
+
+        <span>&#169; Rook Authors {{ site.time | date: '%Y' }}. Documentation distributed under <a href="https://creativecommons.org/licenses/by/4.0">CC-BY-4.0</a>.</span>
+
+        <br />
+
+        <span>&#169; {{ site.time | date: '%Y' }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a> page.</span>
+      </div>
+    </div>
   </div>
 </footer>
 


### PR DESCRIPTION
This PR adds the Linux Foundation's required copyright text to the site footer.

cc @jbw976

<img width="663" alt="Screen Shot 2020-05-19 at 10 58 03 AM" src="https://user-images.githubusercontent.com/1523104/82361661-ff584680-99bf-11ea-9fc1-3cdd25dfa1b3.png">

I'm not really familiar with the CSS framework so perhaps someone can follow up and make it prettier.
