### PR TITLE
Makefile improvement and meta noindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+JEKYLL_DOCKER_IMAGE ?= jekyll/jekyll:3.7
+
 # Run jekyll in development mode
 run: _data/projects.json
 	docker run --rm -it \
 		-p 4000:4000 -p 4001:4001 \
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
-		jekyll/jekyll -- \
+		$(JEKYLL_DOCKER_IMAGE) -- \
 		jekyll serve --livereload --livereload-port 4001
 
 # Build (output is in _site)
@@ -12,7 +14,7 @@ build: _data/projects.json
 	docker run --rm -it \
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
-		jekyll/jekyll -- \
+		$(JEKYLL_DOCKER_IMAGE) -- \
 		jekyll build
 
 # Push new changes to the live site

--- a/_includes/values_docs.inc
+++ b/_includes/values_docs.inc
@@ -1,0 +1,14 @@
+{% assign url = page.url | split: '/' %}
+{% assign currentProject = url[2] %}
+{% assign currentVersion = url[3] %}
+{% assign currentPath = '' %}
+{% for i in url %}
+{% if forloop.index0 >= 4 %}
+{% assign currentPath = currentPath | append: '/' | append: url[forloop.index0] %}
+{% endif %}
+{% endfor %}
+{% assign latestVersion = site.data.projects[0].versions[site.current_release_index].version %}
+{% assign currentProjectPath = '/docs/' | append: currentProject | append: '/' %}
+{% assign currentProjectVersionPath = currentProjectPath | append: currentVersion | append: '/' %}
+{% assign project = site.data.projects | where_exp: 'item', 'item.project == currentProject' | first %}
+{% assign filepath = page.url | replace: currentProjectVersionPath %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,24 @@
 {% include values.inc %}
 
+{% comment %}
+If this a docs page, include the docs values and check if the page should be "noindex"ed
+{% endcomment %}
+
+{% assign url = page.url | split: '/' %}
+{% if url.size > 1 and url[1] == "docs" %}
+{% include values_docs.inc %}
+{% endif %}
+
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+
+    {% if currentVersion and latestVersion and currentVersion != latestVersion %}
+    <meta name="robots" content="noindex">
+    {% endif %}
 
     <title>{{ page.doctitle | default: "Rook" | escape }}</title>
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,20 +2,7 @@
 layout: default
 ---
 
-{% assign url = page.url | split: '/' %}
-{% assign currentProject = url[2] %}
-{% assign currentVersion = url[3] %}
-{% assign currentPath = '' %}
-{% for i in url %}
-{% if forloop.index0 >= 4 %}
-{% assign currentPath = currentPath | append: '/' | append: url[forloop.index0] %}
-{% endif %}
-{% endfor %}
-{% assign latestVersion = site.data.projects[0].versions[site.current_release_index].version %}
-{% assign currentProjectPath = '/docs/' | append: currentProject | append: '/' %}
-{% assign currentProjectVersionPath = currentProjectPath | append: currentVersion | append: '/' %}
-{% assign project = site.data.projects | where_exp: 'item', 'item.project == currentProject' | first %}
-{% assign filepath = page.url | replace: currentProjectVersionPath %}
+{% include values_docs.inc %}
 
 {% assign documents = site.pages | where_exp: 'page', 'page.url contains currentProjectVersionPath' | sort: 'weight' %}
 


### PR DESCRIPTION
make: added jekyll docker image variable

Use Jekyll image 3.7 due to the older bundler version used in this
repository.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

layouts: put meta noindex for non latester version docs

Put the meta noindex tag for non latest version docs pages.
This should prevent master and non latest / current version docs to not
appear in search results anymore.

Resolves #91

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

The liquid template changes are probably not made in the best way, any feedback on how to handle this better is welcome!