### PR TITLE
Docs: Set the default index to the v1.3 docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 0
+current_release_index: 1


### PR DESCRIPTION
With the v1.4.0-beta.0 release out, the 1.4 docs are published, but we need to keep the default at the v1.3 docs until v1.4.0 is released.