### PR TITLE
Always render code blocks in normal text

### DIFF
--- a/_scss/minima/_base.scss
+++ b/_scss/minima/_base.scss
@@ -140,6 +140,7 @@ code {
   border: 1px solid $grey-color-light;
   border-radius: 3px;
   background-color: #eef;
+  font-style: normal;
 }
 
 code {


### PR DESCRIPTION
This comes up if a code block is inside of a block quote. Block quotes
render content in italics, but we don't want to force code blocks into
italics, making them harder to read.

Related: 
https://github.com/rook/rook/pull/7268#issuecomment-782297012 
and https://github.com/rook/rook/pull/7268#issuecomment-782299253

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

Ping @travisn @galexrt @jbw976 . Thanks!