### PR TITLE
docs: Enable v1.6 as the latest stable version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,4 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_release_index: 1
+current_release_index: 0


### PR DESCRIPTION
Now v1.6 docs will be marked as the latest stable release instead of v1.5.