### PR TITLE
docs: Reference the correct current project index

### DIFF
--- a/_includes/values_docs.inc
+++ b/_includes/values_docs.inc
@@ -9,19 +9,19 @@
 {% endfor %}
 {% assign current_project_index = 2 %}
 {% if currentProject == 'cassandra' %}
-  {% assign current_release_index = current_cassandra_release_index %}
+  {% assign current_release_index = site.current_cassandra_release_index %}
   {% assign current_project_index = 0 %}
   {% assign current_project_name = 'Cassandra' %}
 {% elsif currentProject == 'nfs' %}
-  {% assign current_release_index = current_nfs_release_index %}
+  {% assign current_release_index = site.current_nfs_release_index %}
   {% assign current_project_index = 1 %}
   {% assign current_project_name = 'NFS' %}
 {% else %}
-  {% assign current_release_index = current_ceph_release_index %}
+  {% assign current_release_index = site.current_ceph_release_index %}
   {% assign current_project_index = 2 %}
   {% assign current_project_name = 'Ceph' %}
 {% endif %}
-{% assign latestVersion = site.data.projects[current_project_index].versions[site.current_release_index].version %}
+{% assign latestVersion = site.data.projects[current_project_index].versions[current_release_index].version %}
 {% assign latestCassandraVersion = site.data.projects[0].versions[site.current_cassandra_release_index].version %}
 {% assign latestNFSVersion = site.data.projects[1].versions[site.current_nfs_release_index].version %}
 {% assign latestCephVersion = site.data.projects[2].versions[site.current_ceph_release_index].version %}


### PR DESCRIPTION
The current project index is defined in the site, rather than in the current document. Now the message about the docs not being related to the latest current release will not be shown as expected if actually on the latest release docs. This was a regression from #113.
