### PR TITLE
Simplify documentation related to finding the current version

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -28,14 +28,11 @@ layout: default
     </div>
     {% if currentVersion == "latest" %}
       <div class="alert master">
-        <p><b>PLEASE NOTE</b>: This document applies to an <b>unreleased</b> version of Rook. It is strongly recommended that you only use official releases of Rook, as unreleased versions are subject to changes and incompatibilities that will not be supported in the official releases.</p>
-        <p>If you are using an official release version of Rook, you should refer to the documentation for your specific version.</p>
-        <strong>Documentation for other releases can be found by using the version selector in the bottom left of any doc page.</strong>
+        <p><b>PLEASE NOTE:</b> This document applies to an <b>unreleased</b> version of Rook. It is strongly recommended that you only use official releases of Rook, as unreleased versions are subject to changes and incompatibilities that will not be supported in the official releases.</p>
       </div>
     {% elsif currentVersion != latestVersion %}
       <div class="alert old">
         <p><b>PLEASE NOTE</b>: This document applies to {{ currentVersion }} version and not to the latest <strong>stable</strong> release {{ latestVersion }}</p>
-        <strong>Documentation for other releases can be found by using the version selector in the top right of any doc page.</strong>
       </div>
     {% endif %}
     <div class="docs-text">


### PR DESCRIPTION
We do not need to state the obvious of how to find the correct version of the documentation. The docs version is at the top of the page, which is very self-explanatory. The instructions for where to find the link weren't even correct since they referred to the bottom left corner of the page instead of the top right.
