### PR TITLE
footer: add support providers section

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,6 +37,11 @@
         <a href="{{ suseLink }}">SUSE</a>
         <a href="{{ upboundLink }}">Upbound</a>
       </div>
+      <div class="col_sm-12">
+        <span>Support Providers</span>
+        <a href="{{ koorLink }}">Koor Technologies, Inc.</a>
+        <a href="{{ redHatLink }}">Red Hat</a>
+      </div>
     </div>
   </div>
   <div class="bottom">


### PR DESCRIPTION
This adds a support providers section to the footer.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

Separated from #129 as commented by @travisn.