### PR TITLE
don't copy the assets directory during publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ publish: build
 	rsync -rv --delete \
 		--exclude .git/ \
 		--exclude _site/ \
+		--exlude assets/ \
 		--exclude CNAME \
 		--exclude docs/ \
 		--exclude vendor/ \


### PR DESCRIPTION
The assets directory is currently being copied to the `gh-pages` branch
when using the `publish` target. It should not be copied to it.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>