### PR TITLE
nfs: Add deprecation notice to html docs

### DIFF
--- a/docs/nfs/latest/common-issues.html
+++ b/docs/nfs/latest/common-issues.html
@@ -156,6 +156,8 @@
     <div class="docs-text">
       <h1 id="common-issues">Common Issues</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>To help troubleshoot your Rook clusters, here are some tips on what information will help solve the issues you might be seeing.
 If after trying the suggestions found on this page and the problem is not resolved, the Rook team is very happy to help you troubleshoot the issues in their Slack channel. Once you have <a href="https://slack.rook.io">registered for the Rook Slack</a>, proceed to the General channel to ask for assistance.</p>
 

--- a/docs/nfs/latest/development-flow.html
+++ b/docs/nfs/latest/development-flow.html
@@ -156,6 +156,8 @@
     <div class="docs-text">
       <h1 id="contributing">Contributing</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Thank you for your time and effort to help us improve Rook! Here are a few steps to get started. If you have any questions,
 don’t hesitate to reach out to us on our <a href="https://rook-io.slack.com">Slack</a> dev channel.</p>
 

--- a/docs/nfs/latest/index.html
+++ b/docs/nfs/latest/index.html
@@ -156,6 +156,8 @@
     <div class="docs-text">
       <h1 id="rook">Rook</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Rook is an open source <strong>cloud-native storage orchestrator</strong>, providing the platform, framework, and support for a diverse set of storage solutions to natively integrate with cloud-native environments.</p>
 
 <p>Rook turns storage software into self-managing, self-scaling, and self-healing storage services. It does this by automating deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management. Rook uses the facilities provided by the underlying cloud-native container management, scheduling and orchestration platform to perform its duties.</p>

--- a/docs/nfs/latest/k8s-pre-reqs.html
+++ b/docs/nfs/latest/k8s-pre-reqs.html
@@ -157,6 +157,8 @@
       
 <h1 id="prerequisites">Prerequisites</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Rook can be installed on any existing Kubernetes cluster as long as it meets the minimum version
 and Rook is granted the required privileges (see below for more information).</p>
 

--- a/docs/nfs/latest/nfs-crd.html
+++ b/docs/nfs/latest/nfs-crd.html
@@ -156,6 +156,8 @@
     <div class="docs-text">
       <h1 id="nfs-server-crd">NFS Server CRD</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>NFS Server can be created and configured using the <code class="language-plaintext highlighter-rouge">nfsservers.nfs.rook.io</code> custom resource definition (CRD).
 Please refer to the <a href="nfs.md">user guide walk-through</a> for complete instructions.
 This page will explain all the available configuration options on the NFS CRD.</p>

--- a/docs/nfs/latest/quickstart.html
+++ b/docs/nfs/latest/quickstart.html
@@ -157,6 +157,8 @@
       
 <h1 id="network-filesystem-nfs-quickstart">Network Filesystem (NFS) Quickstart</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Welcome to Rook! We hope you have a great experience installing the Rook <strong>cloud-native storage orchestrator</strong> platform
 to enable highly available, durable storage in your Kubernetes cluster.</p>
 

--- a/docs/nfs/v1.7/common-issues.html
+++ b/docs/nfs/v1.7/common-issues.html
@@ -155,6 +155,8 @@ If after trying the suggestions found on this page and the problem is not resolv
 
 <h1 id="troubleshooting-techniques">Troubleshooting Techniques</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Kubernetes status and logs are the the main resources needed to investigate issues in any Rook cluster.</p>
 
 <h2 id="kubernetes-tools">Kubernetes Tools</h2>

--- a/docs/nfs/v1.7/development-flow.html
+++ b/docs/nfs/v1.7/development-flow.html
@@ -150,6 +150,8 @@
     <div class="docs-text">
       <h1 id="contributing">Contributing</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Thank you for your time and effort to help us improve Rook! Here are a few steps to get started. If you have any questions,
 don’t hesitate to reach out to us on our <a href="https://rook-io.slack.com">Slack</a> dev channel.</p>
 

--- a/docs/nfs/v1.7/index.html
+++ b/docs/nfs/v1.7/index.html
@@ -150,6 +150,8 @@
     <div class="docs-text">
       <h1 id="rook">Rook</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Rook is an open source <strong>cloud-native storage orchestrator</strong>, providing the platform, framework, and support for a diverse set of storage solutions to natively integrate with cloud-native environments.</p>
 
 <p>Rook turns storage software into self-managing, self-scaling, and self-healing storage services. It does this by automating deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management. Rook uses the facilities provided by the underlying cloud-native container management, scheduling and orchestration platform to perform its duties.</p>

--- a/docs/nfs/v1.7/k8s-pre-reqs.html
+++ b/docs/nfs/v1.7/k8s-pre-reqs.html
@@ -151,6 +151,8 @@
       
 <h1 id="prerequisites">Prerequisites</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Rook can be installed on any existing Kubernetes cluster as long as it meets the minimum version
 and Rook is granted the required privileges (see below for more information).</p>
 

--- a/docs/nfs/v1.7/nfs-crd.html
+++ b/docs/nfs/v1.7/nfs-crd.html
@@ -150,6 +150,8 @@
     <div class="docs-text">
       <h1 id="nfs-server-crd">NFS Server CRD</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>NFS Server can be created and configured using the <code class="language-plaintext highlighter-rouge">nfsservers.nfs.rook.io</code> custom resource definition (CRD).
 Please refer to the <a href="nfs.md">user guide walk-through</a> for complete instructions.
 This page will explain all the available configuration options on the NFS CRD.</p>

--- a/docs/nfs/v1.7/quickstart.html
+++ b/docs/nfs/v1.7/quickstart.html
@@ -151,6 +151,8 @@
       
 <h1 id="network-filesystem-nfs-quickstart">Network Filesystem (NFS) Quickstart</h1>
 
+<p><strong>The Rook NFS operator is <a href="https://github.com/rook/nfs#deprecated">deprecated</a></strong></p>
+
 <p>Welcome to Rook! We hope you have a great experience installing the Rook <strong>cloud-native storage orchestrator</strong> platform
 to enable highly available, durable storage in your Kubernetes cluster.</p>
 


### PR DESCRIPTION
Manually add the deprecation notice to the html docs from https://github.com/rook/nfs/pull/50 since the publish action isn't working anymore for legacy docs. 