### PR TITLE
Update the help docs index to still point to 1.9

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,6 @@ defaults:
 sass:
   sass_dir: ./_scss
 
-current_ceph_release_index: 0
+current_ceph_release_index: 1
 current_cassandra_release_index: 0
 current_nfs_release_index: 0


### PR DESCRIPTION
After 1.10 is officially released we will change this index again. For now, 1.9 docs are still considered the latest stable.
