### PR TITLE
docs: Remove cassandra and nfs doc links from website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,40 +23,20 @@ exclude:
   - vendor
 
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
     values:
       layout: default
       title: "Rook"
-  -
-    scope:
+  - scope:
       path: "docs/rook"
     values:
       layout: "docs"
-      doctitle: "Ceph Docs"
+      doctitle: "Rook Docs"
       github: "https://github.com/rook/rook/blob/master/Documentation/"
-      stylesheet: "docs"
-  -
-    scope:
-      path: "docs/cassandra"
-    values:
-      layout: "docs"
-      doctitle: "Cassandra Docs"
-      github: "https://github.com/rook/cassandra/blob/master/Documentation/"
-      stylesheet: "docs"
-  -
-    scope:
-      path: "docs/nfs"
-    values:
-      layout: "docs"
-      doctitle: "NFS Docs"
-      github: "https://github.com/rook/nfs/blob/master/Documentation/"
       stylesheet: "docs"
 
 sass:
   sass_dir: ./_scss
 
-current_ceph_release_index: 0
-current_cassandra_release_index: 0
-current_nfs_release_index: 0
+current_release_index: 0

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,19 +3,13 @@
     <div class="logo">
       <a href="{{ "/" | relative_url }}"><img src="{{ "/images/rook-logo.svg" | relative_url }}"/></a>
     </div>
-    <div
+    <div 
       class="hamburger-controls"
       onclick="if (document.body.classList.contains('menu-open')) { document.body.classList.remove('menu-open') } else { document.body.classList.add('menu-open') }; return false;">
       <span></span> <span></span> <span></span>
     </div>
     <ul class="links">
-      <li class="dropdown">
-        <a role="button" href="javascript:void(0)">Documentation</a>
-        <div class="dropdown-content">
-          <a href="{{ cephDocLink }}">Ceph</a>
-          <a href="{{ cassandraDocLink }}">Cassandra</a>
-          <a href="{{ nfsDocLink }}">NFS</a>
-        </div>
+      <li><a href="{{ latestDocs }}">Documentation</a></li>
       <li class="dropdown">
         <a role="button" href="javascript:void(0)">Community</a>
         <div class="dropdown-content">

--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -8,9 +8,6 @@
 {% assign forumLink = '//groups.google.com/forum/#!forum/rook-dev' %}
 {% assign gettingStartedLink = '/docs/rook/latest-release/Getting-Started/quickstart/' %}
 {% assign githubLink = '//github.com/rook/rook' %}
-{% assign cassandraDocLink = '/docs/cassandra/v1.7/' %}
-{% assign nfsDocLink = '/docs/nfs/v1.7/' %}
-{% assign cephDocLink = '/docs/rook/latest-release/' %}
 {% assign latestDocs = '/docs/rook/latest-release/' %}
 {% assign cybozuLink = '//cybozu.com' %}
 {% assign redHatLink = '//www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation' %}


### PR DESCRIPTION
Rook.io will only link to the main rook docs for the Ceph provider. The Cassandra and NFS operators have not been supported and are fully deprecated, so there is no need to link to the docs from the website. The docs are still available if anyone is using them, they are just not linked from the main site.

These links were first added with #113, now effectively reverting those changes where multiple storage providers were linked from the main website.