### PR TITLE
ci: fix up auto build of master branch changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,12 +15,21 @@ permissions:
 
 jobs:
   build-and-publish-website:
+    # Depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       
       - name: Build and publish website
         run: |


### PR DESCRIPTION
This works fine in a repository I own to have a script/ action push changes to the repository it is running in.