### PR TITLE
Remove Koor from support providers

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,13 +33,11 @@
         <span>Top Contributors</span>
         <a href="{{ cloudicalLink }}">Cloudical</a>
         <a href="{{ cybozuLink }}">Cybozu, Inc</a>
-        <a href="{{ koorLink }}">Koor Technologies, Inc.</a>
         <a href="{{ redHatLink }}">Red Hat</a>
         <a href="{{ upboundLink }}">Upbound</a>
       </div>
       <div class="col_sm-12">
         <span>Support Providers</span>
-        <a href="{{ koorLink }}">Koor Technologies, Inc.</a>
         <a href="{{ redHatLink }}">Red Hat</a>
       </div>
     </div>

--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -13,6 +13,5 @@
 {% assign cloudicalLink = '//cloudical.io/' %}
 {% assign cncfLink = '//www.cncf.io' %}
 {% assign cybozuLink = '//cybozu.com' %}
-{% assign koorLink = '//koor.tech' %}
 {% assign redHatLink = '//www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation' %}
 {% assign upboundLink = '//upbound.io' %}

--- a/support.html
+++ b/support.html
@@ -31,21 +31,6 @@ stylesheet: index
     <!-- Support Providers -->
     <div class="providers">
         <section class="col-12_md-12">
-            <h2><a href="{{ koorLink }}">Koor Technologies, Inc.</a></h2>
-            <p>
-                Koor Technologies offers a variety of services and products to help you with Ceph data storage. Choose stand-alone Ceph or use Rook to connect your storage to Kubernetes. Get help from Koor experts at every step.
-                    
-                <br />
-                Services include:
-                <ul>
-                    <li>Managed Ceph and Rook service, consulting and support.</li>
-                    <li>Hosted Rook Ceph clusters.</li>
-                    <li>Data Control Center application for insights into Rook Ceph clusters.</li>
-                </ul>
-            </p>
-        </section>
-
-        <section class="col-12_md-12">
             <h2><a href="{{ redHatLink }}">Red Hat</a></h2>
             <p>
                 Red Hat® OpenShift® Data Foundation is software-defined storage for containers. Red Hat OpenShift Data Foundation helps teams develop and deploy applications with storage quickly and efficiently across clouds.


### PR DESCRIPTION
Remove Koor from the page of Rook support providers since it is no longer supported.