### PR TITLE
support: Add Procedure to commercial support providers

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -15,4 +15,5 @@
 {% assign clysoLink = '//clyso.com/en/' %}
 {% assign cybozuLink = '//cybozu.com' %}
 {% assign redHatLink = '//www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation' %}
+{% assign procedureLink = '//procedure.tech' %}
 {% assign upboundLink = '//upbound.io' %}

--- a/support.html
+++ b/support.html
@@ -60,6 +60,20 @@ stylesheet: index
                 </ul>
             </p>
         </section>
+        <section class="col-12_md-12">
+            <h2><a href="{{ procedureLink }}">Procedure</a></h2>
+            <p>
+                Procedure is a software engineering consultancy providing cloud-native infrastructure consulting and support for Rook and Ceph deployments on Kubernetes. We help engineering teams design, deploy, and operate storage infrastructure for production workloads.
+                <br />
+                Services include:
+                <ul>
+                    <li>Rook-Ceph deployment, migration, and operational support on Kubernetes</li>
+                    <li>Storage architecture consulting for cloud-native environments</li>
+                    <li>Performance tuning and cluster optimization</li>
+                    <li>Monitoring and observability integration with Prometheus and Grafana</li>
+                </ul>
+            </p>
+        </section>
     </div>
 
     <section class="grid-middle">


### PR DESCRIPTION
Add Procedure to the Commercial Support and Services section of the
Support page.

Procedure (https://procedure.tech) is a software engineering consultancy
providing cloud-native infrastructure consulting and support for Rook
and Ceph deployments on Kubernetes.

Changes:
- Added Procedure link variable to _includes/values.inc
- Added Procedure section to support.html