### PR TITLE
docs: Update the support page for adding new companies to the list

### DIFF
--- a/support.html
+++ b/support.html
@@ -65,7 +65,10 @@ stylesheet: index
     <section class="grid-middle">
         <div class="col-12_md-12">
             <p>
-                To add your company to the list of support providers, please open a pull request against the <a href="https://github.com/rook/rook.github.io">rook.github.io repository</a>.
+                Does your company want to be added to the list of support providers? If so, open an
+                <a href="https://github.com/rook/rook.github.io/issues">issue</a> with
+                details about your company and your plans for contributing back to the Rook
+                community. Rook maintainers will look forward to your contributions!
             </p>
         </div>
     </section>


### PR DESCRIPTION
To be included on the support page, companies should have some commitment to the upstream community and be willing to contribute. This is a simple request to start a conversation with maintainers on what their plan is to contribute back to the community.