### PR TITLE
fix: add missing alt attributes to images

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,8 @@
       <img
         class="cncf"
         src="{{ "/images/cncf.png" | relative_url }}"
-        srcset="{{ "/images/cncf@2x.png" | relative_url }} 2x, {{ "/images/cncf@3x.png" | relative_url }} 3x" />
+        srcset="{{ "/images/cncf@2x.png" | relative_url }} 2x, {{ "/images/cncf@3x.png" | relative_url }} 3x"
+        alt="Cloud Native Computing Foundation" />
     </a>
     <p>We are a Cloud Native Computing Foundation graduated project.</p>
   </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ stylesheet: index
             <a class="button" href="{{ gettingStartedLink }}">Try it out now</a>
         </div>
         <div class="col-7_md-12_md-first">
-            <img src="{{ "/images/index-hero.svg" | relative_url }}" />
+            <img src="{{ "/images/index-hero.svg" | relative_url }}" alt="" />
         </div>
     </section>
     <section class="grid-middle">
@@ -22,7 +22,7 @@ stylesheet: index
     </section>
     <section class="grid-middle">
         <div class="col-6_md-12">
-            <img src="{{ "/images/index-what-is-rook.svg" | relative_url }}" />
+            <img src="{{ "/images/index-what-is-rook.svg" | relative_url }}" alt="" />
         </div>
         <div class="col-6_md-12">
             <h2>Storage Operators for Kubernetes</h2>
@@ -77,35 +77,35 @@ stylesheet: index
     </section>
     <section class="grid-bottom features">
         <div class="col-3_xs-6">
-            <img class="automate" src="{{ "/images/features/automate.svg" | relative_url }}" />
+            <img class="automate" src="{{ "/images/features/automate.svg" | relative_url }}" alt="" />
             <span>Simple and reliable automated storage management</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="scale" src="{{ "/images/features/scale.svg" | relative_url }}" />
+            <img class="scale" src="{{ "/images/features/scale.svg" | relative_url }}" alt="" />
             <span>Hyper-scale or hyper-converge your storage clusters</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="distribute" src="{{ "/images/features/distribute.svg" | relative_url }}" />
+            <img class="distribute" src="{{ "/images/features/distribute.svg" | relative_url }}" alt="" />
             <span>Efficiently distribute and replicate data to minimize loss</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="provision" src="{{ "/images/features/provision.svg" | relative_url }}" />
+            <img class="provision" src="{{ "/images/features/provision.svg" | relative_url }}" alt="" />
             <span>Provision, file, block, and object storage</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="manage" src="{{ "/images/features/manage.svg" | relative_url }}" />
+            <img class="manage" src="{{ "/images/features/manage.svg" | relative_url }}" alt="" />
             <span>Manage open-source Ceph storage</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="elasticstorage" src="{{ "/images/features/elasticstorage.svg" | relative_url }}" />
+            <img class="elasticstorage" src="{{ "/images/features/elasticstorage.svg" | relative_url }}" alt="" />
             <span>Easily enable elastic storage in your datacenter</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="opensource" src="{{ "/images/features/opensource.svg" | relative_url }}" />
+            <img class="opensource" src="{{ "/images/features/opensource.svg" | relative_url }}" alt="" />
             <span>Open source software released under the Apache 2.0 license</span>
         </div>
         <div class="col-3_xs-6">
-            <img class="optimize" src="{{ "/images/features/optimize.svg" | relative_url }}" />
+            <img class="optimize" src="{{ "/images/features/optimize.svg" | relative_url }}" alt="" />
             <span>Optimize workloads on commodity hardware</span>
         </div>
     </section>

--- a/support.html
+++ b/support.html
@@ -19,7 +19,7 @@ stylesheet: index
             </p>
         </div>
         <div class="col-7_md-12_md-first">
-            <img src="{{ "/images/index-what-is-rook.svg" | relative_url }}" />
+            <img src="{{ "/images/index-what-is-rook.svg" | relative_url }}" alt="" />
         </div>
     </section>
     <section class="grid-middle">


### PR DESCRIPTION
12 `<img>` tags across the site are missing `alt` attributes, which breaks screen reader support (WCAG 2.1 sc 1.1.1). Worst case is the CNCF logo in the footer - it's wrapped in an `<a>` tag with no alt text, so screen readers just announce the raw filename.

Reproduce: open rook.io with a screen reader (e.g. NVDA + Chrome or VoiceOver on mac), tab to the footer CNCF link - you get "link: /images/cncf.png" or similar instead of anything useful.

Fix: decorative icons and layout images get `alt=""` so screen readers skip em; the CNCF footer link gets `alt="Cloud Native Computing Foundation"` since its the only content in that anchor.

Signed-off-by: immanuwell <pchpr.00@list.ru>